### PR TITLE
Token Introspection (rfc7662)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+go-oauth2-server

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ It relies on `Postgres` for database and `etcd` for configuration but both are e
       * [Resource Owner Password Credentials](#resource-owner-password-credentials)
       * [Client Credentials](#client-credentials)
     * [Refreshing An Access Token](#refreshing-an-access-token)
+    * [Token Introspection](#token-introspection)
 * [Development](#development)
   * [Dependencies](#dependencies)
   * [Setup](#setup)
@@ -343,6 +344,32 @@ If valid and authorized, the authorization server issues an access token.
 ```
 
 The authorization server MAY issue a new refresh token, in which case the client MUST discard the old refresh token and replace it with the new refresh token.  The authorization server MAY revoke the old refresh token after issuing a new refresh token to the client.  If a new refresh token is issued, the refresh token scope MUST be identical to that of the refresh token included by the client in the request.
+
+### Token Introspection
+
+https://tools.ietf.org/html/rfc7662
+
+If the authorization server issued a access token or refresh token to the client, the client can make a request to the introspect endpoint in order to learn meta-information about a token.
+
+```
+curl --compressed -v localhost:8080/v1/oauth/introspect \
+	-u test_client:test_secret \
+	-d "token=00ccd40e-72ca-4e79-a4b6-67c95e2e3f1c" \
+	-d "token_type_hint=access_token"
+```
+
+The authorization server responds meta-information about a token.
+
+```json
+{
+	"active": true,
+	"scope": "read_write",
+	"client_id": "test_client",
+	"username": "test@username",
+	"token_type": "Bearer",
+	"exp": 1454868090
+}
+```
 
 # Development
 

--- a/commands/run_server.go
+++ b/commands/run_server.go
@@ -14,10 +14,10 @@ import (
 // RunServer runs the app
 func RunServer() error {
 	cnf, db, err := initConfigDB(true, true)
-	defer db.Close()
 	if err != nil {
 		return err
 	}
+	defer db.Close()
 
 	// Initialise the health service
 	healthService := health.NewService(db)

--- a/oauth/access_token.go
+++ b/oauth/access_token.go
@@ -6,6 +6,9 @@ import (
 	"github.com/RichardKnop/go-oauth2-server/util"
 )
 
+// TokenType is default type of generated tokens.
+const TokenType = "Bearer"
+
 // GrantAccessToken deletes old tokens and grants a new access token
 func (s *Service) GrantAccessToken(client *Client, user *User, scope string) (*AccessToken, error) {
 	// Delete expired access tokens

--- a/oauth/grant_type_authorization_code.go
+++ b/oauth/grant_type_authorization_code.go
@@ -59,7 +59,7 @@ func (s *Service) authorizationCodeGrant(w http.ResponseWriter, r *http.Request,
 		ID:           accessToken.ID,
 		AccessToken:  accessToken.Token,
 		ExpiresIn:    s.cnf.Oauth.AccessTokenLifetime,
-		TokenType:    "Bearer",
+		TokenType:    TokenType,
 		Scope:        accessToken.Scope,
 		RefreshToken: refreshToken.Token,
 	}

--- a/oauth/grant_type_authorization_code_test.go
+++ b/oauth/grant_type_authorization_code_test.go
@@ -74,7 +74,7 @@ func (suite *OauthTestSuite) TestAuthorizationCodeGrant() {
 		ID:           accessToken.ID,
 		AccessToken:  accessToken.Token,
 		ExpiresIn:    3600,
-		TokenType:    "Bearer",
+		TokenType:    TokenType,
 		Scope:        "read_write",
 		RefreshToken: refreshToken.Token,
 	})

--- a/oauth/grant_type_client_credentials.go
+++ b/oauth/grant_type_client_credentials.go
@@ -41,7 +41,7 @@ func (s *Service) clientCredentialsGrant(w http.ResponseWriter, r *http.Request,
 		ID:           accessToken.ID,
 		AccessToken:  accessToken.Token,
 		ExpiresIn:    s.cnf.Oauth.AccessTokenLifetime,
-		TokenType:    "Bearer",
+		TokenType:    TokenType,
 		Scope:        accessToken.Scope,
 		RefreshToken: refreshToken.Token,
 	}

--- a/oauth/grant_type_client_credentials_test.go
+++ b/oauth/grant_type_client_credentials_test.go
@@ -40,7 +40,7 @@ func (suite *OauthTestSuite) TestClientCredentialsGrant() {
 		ID:           accessToken.ID,
 		AccessToken:  accessToken.Token,
 		ExpiresIn:    3600,
-		TokenType:    "Bearer",
+		TokenType:    TokenType,
 		Scope:        "read_write",
 		RefreshToken: refreshToken.Token,
 	})

--- a/oauth/grant_type_password.go
+++ b/oauth/grant_type_password.go
@@ -58,7 +58,7 @@ func (s *Service) passwordGrant(w http.ResponseWriter, r *http.Request, client *
 		ID:           accessToken.ID,
 		AccessToken:  accessToken.Token,
 		ExpiresIn:    s.cnf.Oauth.AccessTokenLifetime,
-		TokenType:    "Bearer",
+		TokenType:    TokenType,
 		Scope:        accessToken.Scope,
 		RefreshToken: refreshToken.Token,
 	}

--- a/oauth/grant_type_password_test.go
+++ b/oauth/grant_type_password_test.go
@@ -42,7 +42,7 @@ func (suite *OauthTestSuite) TestPasswordGrant() {
 		ID:           accessToken.ID,
 		AccessToken:  accessToken.Token,
 		ExpiresIn:    3600,
-		TokenType:    "Bearer",
+		TokenType:    TokenType,
 		Scope:        "read_write",
 		RefreshToken: refreshToken.Token,
 	})

--- a/oauth/grant_type_refresh_token.go
+++ b/oauth/grant_type_refresh_token.go
@@ -63,7 +63,7 @@ func (s *Service) refreshTokenGrant(w http.ResponseWriter, r *http.Request, clie
 		ID:           accessToken.ID,
 		AccessToken:  accessToken.Token,
 		ExpiresIn:    s.cnf.Oauth.AccessTokenLifetime,
-		TokenType:    "Bearer",
+		TokenType:    TokenType,
 		Scope:        accessToken.Scope,
 		RefreshToken: refreshToken.Token,
 	}

--- a/oauth/grant_type_refresh_token_test.go
+++ b/oauth/grant_type_refresh_token_test.go
@@ -89,7 +89,7 @@ func (suite *OauthTestSuite) TestRefreshTokenGrant() {
 		ID:           accessToken.ID,
 		AccessToken:  accessToken.Token,
 		ExpiresIn:    3600,
-		TokenType:    "Bearer",
+		TokenType:    TokenType,
 		Scope:        "read_write",
 		RefreshToken: "test_token",
 	})

--- a/oauth/handlers.go
+++ b/oauth/handlers.go
@@ -12,6 +12,24 @@ var (
 	errClientAuthenticationRequired = errors.New("Client authentication required")
 )
 
+// Get client credentials from basic auth and try to authenticate client
+func (s *Service) basicAuthClient(r *http.Request) (*Client, error) {
+	// Get client credentials from basic auth
+	clientID, secret, ok := r.BasicAuth()
+	if !ok {
+		return nil, errClientAuthenticationRequired
+	}
+
+	// Authenticate the client
+	client, err := s.AuthClient(clientID, secret)
+	if err != nil {
+		// For security reasons, return a general error message
+		return nil, errClientAuthenticationRequired
+	}
+
+	return client, nil
+}
+
 // Handles all OAuth 2.0 grant types (POST /v1/oauth/tokens)
 func (s *Service) tokensHandler(w http.ResponseWriter, r *http.Request) {
 	// Parse the form so r.Form becomes available
@@ -35,21 +53,23 @@ func (s *Service) tokensHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Get client credentials from basic auth
-	clientID, secret, ok := r.BasicAuth()
-	if !ok {
-		response.UnauthorizedError(w, errClientAuthenticationRequired.Error())
-		return
-	}
-
-	// Authenticate the client
-	client, err := s.AuthClient(clientID, secret)
+	client, err := s.basicAuthClient(r)
 	if err != nil {
-		// For security reasons, return a general error message
-		response.UnauthorizedError(w, errClientAuthenticationRequired.Error())
+		response.UnauthorizedError(w, err.Error())
 		return
 	}
 
 	// Execute the correct function based on the grant type
 	grantHandler(w, r, client)
+}
+
+// Handles OAuth 2.0 introspect request (POST /v1/oauth/introspect)
+func (s *Service) introspectHandler(w http.ResponseWriter, r *http.Request) {
+	client, err := s.basicAuthClient(r)
+	if err != nil {
+		response.UnauthorizedError(w, err.Error())
+		return
+	}
+
+	s.introspectToken(w, r, client)
 }

--- a/oauth/handlers_test.go
+++ b/oauth/handlers_test.go
@@ -57,3 +57,26 @@ func (suite *OauthTestSuite) TestHandleTokensInvalidGrantType() {
 		strings.TrimSpace(w.Body.String()),
 	)
 }
+
+func (suite *OauthTestSuite) TestHandleIntrospectClientAuthenticationRequired() {
+	// Prepare a request
+	r, err := http.NewRequest("POST", "http://1.2.3.4/something", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	r.PostForm = url.Values{"token": {"token"}}
+
+	// And run the function we want to test
+	w := httptest.NewRecorder()
+	suite.service.introspectHandler(w, r)
+
+	// Check the status code
+	assert.Equal(suite.T(), 401, w.Code)
+
+	// Check the response body
+	assert.Equal(
+		suite.T(),
+		fmt.Sprintf("{\"error\":\"%s\"}", errClientAuthenticationRequired.Error()),
+		strings.TrimSpace(w.Body.String()),
+	)
+}

--- a/oauth/introspect.go
+++ b/oauth/introspect.go
@@ -1,0 +1,117 @@
+package oauth
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/RichardKnop/go-oauth2-server/response"
+)
+
+const (
+	accessTokenHint  = "access_token"
+	refreshTokenHint = "refresh_token"
+)
+
+var (
+	errTokenMissing     = errors.New("Token missing")
+	errTokenHintInvalid = errors.New("Invalid token hint")
+)
+
+func (s *Service) introspectToken(w http.ResponseWriter, r *http.Request, client *Client) {
+	// Parse the form so r.Form becomes available
+	if err := r.ParseForm(); err != nil {
+		response.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	token := r.Form.Get("token")
+	if token == "" {
+		response.Error(w, errTokenMissing.Error(), http.StatusBadRequest)
+		return
+	}
+
+	tokenTypeHint := r.Form.Get("token_type_hint")
+
+	if tokenTypeHint == "" {
+		tokenTypeHint = accessTokenHint
+	}
+
+	var ir *IntrospectResponse
+
+	switch tokenTypeHint {
+	case accessTokenHint:
+		var ok bool
+		ir, ok = s.introspectAccessToken(w, token)
+		if !ok {
+			ir, _ = s.introspectRefreshToken(w, token, client)
+		}
+	case refreshTokenHint:
+		var ok bool
+		ir, ok = s.introspectRefreshToken(w, token, client)
+		if !ok {
+			ir, _ = s.introspectAccessToken(w, token)
+		}
+	default:
+		response.Error(w, errTokenHintInvalid.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if ir == nil {
+		ir = &IntrospectResponse{}
+	}
+
+	response.WriteJSON(w, ir, 200)
+}
+
+func (s *Service) IntrospectResponseAccessToken(at *AccessToken) *IntrospectResponse {
+	ir := IntrospectResponse{
+		Active:    true,
+		Scope:     at.Scope,
+		TokenType: TokenType,
+		ExpiresAt: int(at.ExpiresAt.Unix()),
+	}
+	if at.Client != nil {
+		ir.ClientID = at.Client.Key
+	}
+	if at.User != nil {
+		ir.Username = at.User.Username
+	}
+
+	return &ir
+}
+
+// Introspects give token as access token and returns true if it was successful
+func (s *Service) introspectAccessToken(w http.ResponseWriter, token string) (*IntrospectResponse, bool) {
+	at, err := s.Authenticate(token)
+	if err != nil {
+		return nil, false
+	}
+
+	return s.IntrospectResponseAccessToken(at), true
+}
+
+func (s *Service) IntrospectResponseRefreshToken(rt *RefreshToken) *IntrospectResponse {
+	ir := IntrospectResponse{
+		Active:    true,
+		Scope:     rt.Scope,
+		TokenType: TokenType,
+		ExpiresAt: int(rt.ExpiresAt.Unix()),
+	}
+	if rt.Client != nil {
+		ir.ClientID = rt.Client.Key
+	}
+	if rt.User != nil {
+		ir.Username = rt.User.Username
+	}
+	return &ir
+}
+
+// Introspects given token as refresh token and returns true if it was successful
+func (s *Service) introspectRefreshToken(w http.ResponseWriter, token string, client *Client) (*IntrospectResponse, bool) {
+	rt, err := s.GetValidRefreshToken(token, client)
+	if err != nil {
+		return nil, false
+	}
+
+	return s.IntrospectResponseRefreshToken(rt), true
+}

--- a/oauth/introspect_test.go
+++ b/oauth/introspect_test.go
@@ -1,0 +1,311 @@
+package oauth
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func (suite *OauthTestSuite) TestIntrospectResponseAccessToken() {
+	at := AccessToken{
+		Token:     "test_token_introspect_1",
+		ExpiresAt: time.Now().Add(+10 * time.Second),
+		Client:    suite.clients[0],
+		User:      suite.users[0],
+		Scope:     "read_write",
+	}
+	ir := IntrospectResponse{
+		Active:    true,
+		Scope:     at.Scope,
+		TokenType: TokenType,
+		ExpiresAt: int(at.ExpiresAt.Unix()),
+		ClientID:  at.Client.Key,
+		Username:  at.User.Username,
+	}
+	assert.Equal(suite.T(), &ir, suite.service.IntrospectResponseAccessToken(&at))
+
+	at.Client = nil
+	ir.ClientID = ""
+	assert.Equal(suite.T(), &ir, suite.service.IntrospectResponseAccessToken(&at))
+
+	at.User = nil
+	ir.Username = ""
+	assert.Equal(suite.T(), &ir, suite.service.IntrospectResponseAccessToken(&at))
+}
+
+func (suite *OauthTestSuite) TestIntrospectResponseRefreshToken() {
+	rt := RefreshToken{
+		Token:     "test_token_introspect_1",
+		ExpiresAt: time.Now().Add(+10 * time.Second),
+		Client:    suite.clients[0],
+		User:      suite.users[0],
+		Scope:     "read_write",
+	}
+	ir := IntrospectResponse{
+		Active:    true,
+		Scope:     rt.Scope,
+		TokenType: TokenType,
+		ExpiresAt: int(rt.ExpiresAt.Unix()),
+		ClientID:  rt.Client.Key,
+		Username:  rt.User.Username,
+	}
+	assert.Equal(suite.T(), &ir, suite.service.IntrospectResponseRefreshToken(&rt))
+
+	rt.Client = nil
+	ir.ClientID = ""
+	assert.Equal(suite.T(), &ir, suite.service.IntrospectResponseRefreshToken(&rt))
+
+	rt.User = nil
+	ir.Username = ""
+	assert.Equal(suite.T(), &ir, suite.service.IntrospectResponseRefreshToken(&rt))
+}
+
+func (suite *OauthTestSuite) TestHandleIntrospectMissingToken() {
+	// Make a request
+	r, err := http.NewRequest("POST", "http://1.2.3.4/something", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	r.SetBasicAuth("test_client", "test_secret")
+	r.PostForm = url.Values{}
+
+	// And run the function we want to test
+	w := httptest.NewRecorder()
+	suite.service.introspectHandler(w, r)
+
+	// Check the status code
+	assert.Equal(suite.T(), 400, w.Code)
+
+	// Check the response body
+	assert.Equal(
+		suite.T(),
+		fmt.Sprintf("{\"error\":\"%s\"}", errTokenMissing.Error()),
+		strings.TrimSpace(w.Body.String()),
+	)
+}
+
+func (suite *OauthTestSuite) TestHandleIntrospectInvailidTokenHint() {
+	// Make a request
+	r, err := http.NewRequest("POST", "http://1.2.3.4/something", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	r.SetBasicAuth("test_client", "test_secret")
+	r.PostForm = url.Values{"token": {"token"}, "token_type_hint": {"wrong"}}
+
+	// And run the function we want to test
+	w := httptest.NewRecorder()
+	suite.service.introspectHandler(w, r)
+
+	// Check the status code
+	assert.Equal(suite.T(), 400, w.Code)
+
+	// Check the response body
+	assert.Equal(
+		suite.T(),
+		fmt.Sprintf("{\"error\":\"%s\"}", errTokenHintInvalid.Error()),
+		strings.TrimSpace(w.Body.String()),
+	)
+}
+
+func (suite *OauthTestSuite) TestHandleIntrospectAccessToken() {
+	// Insert a test access token with a user
+	at := &AccessToken{
+		Token:     "test_token_introspect_1",
+		ExpiresAt: time.Now().Add(+10 * time.Second),
+		Client:    suite.clients[0],
+		User:      suite.users[0],
+		Scope:     "read_write",
+	}
+	if err := suite.db.Create(at).Error; err != nil {
+		log.Fatal(err)
+	}
+
+	// Make a request
+	r, err := http.NewRequest("POST", "http://1.2.3.4/something", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	r.SetBasicAuth("test_client", "test_secret")
+
+	// With correct token hint
+	r.PostForm = url.Values{"token": {at.Token}, "token_type_hint": {accessTokenHint}}
+
+	// And run the function we want to test
+	w := httptest.NewRecorder()
+	suite.service.introspectHandler(w, r)
+
+	// Check the status code
+	assert.Equal(suite.T(), 200, w.Code)
+	// Check the response body
+	expected, err := json.Marshal(suite.service.IntrospectResponseAccessToken(at))
+	if err != nil {
+		log.Fatal(err)
+	}
+	assert.Equal(suite.T(), string(expected), strings.TrimSpace(w.Body.String()))
+
+	// With incorrect token hint
+	r.PostForm = url.Values{"token": {at.Token}, "token_type_hint": {refreshTokenHint}}
+
+	// And run the function we want to test
+	w = httptest.NewRecorder()
+	suite.service.introspectHandler(w, r)
+
+	// Check the status code
+	assert.Equal(suite.T(), 200, w.Code)
+	// Check the response body
+	expected, err = json.Marshal(suite.service.IntrospectResponseAccessToken(at))
+	if err != nil {
+		log.Fatal(err)
+	}
+	assert.Equal(suite.T(), string(expected), strings.TrimSpace(w.Body.String()))
+
+	// Without token hint
+	r.PostForm = url.Values{"token": {at.Token}}
+
+	// And run the function we want to test
+	w = httptest.NewRecorder()
+	suite.service.introspectHandler(w, r)
+
+	// Check the status code
+	assert.Equal(suite.T(), 200, w.Code)
+	// Check the response body
+	expected, err = json.Marshal(suite.service.IntrospectResponseAccessToken(at))
+	if err != nil {
+		log.Fatal(err)
+	}
+	assert.Equal(suite.T(), string(expected), strings.TrimSpace(w.Body.String()))
+}
+
+func (suite *OauthTestSuite) TestHandleIntrospectRefreshToken() {
+	// Insert a test access token with a user
+	rt := &RefreshToken{
+		Token:     "test_token_introspect_1",
+		ExpiresAt: time.Now().Add(+10 * time.Second),
+		Client:    suite.clients[0],
+		User:      suite.users[0],
+		Scope:     "read_write",
+	}
+	if err := suite.db.Create(rt).Error; err != nil {
+		log.Fatal(err)
+	}
+
+	// Make a request
+	r, err := http.NewRequest("POST", "http://1.2.3.4/something", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	r.SetBasicAuth("test_client", "test_secret")
+
+	// With correct token hint
+	r.PostForm = url.Values{"token": {rt.Token}, "token_type_hint": {refreshTokenHint}}
+
+	// And run the function we want to test
+	w := httptest.NewRecorder()
+	suite.service.introspectHandler(w, r)
+
+	// Check the status code
+	assert.Equal(suite.T(), 200, w.Code)
+	// Check the response body
+	expected, err := json.Marshal(suite.service.IntrospectResponseRefreshToken(rt))
+	if err != nil {
+		log.Fatal(err)
+	}
+	assert.Equal(suite.T(), string(expected), strings.TrimSpace(w.Body.String()))
+
+	// With incorrect token hint
+	r.PostForm = url.Values{"token": {rt.Token}, "token_type_hint": {accessTokenHint}}
+
+	// And run the function we want to test
+	w = httptest.NewRecorder()
+	suite.service.introspectHandler(w, r)
+
+	// Check the status code
+	assert.Equal(suite.T(), 200, w.Code)
+	// Check the response body
+	expected, err = json.Marshal(suite.service.IntrospectResponseRefreshToken(rt))
+	if err != nil {
+		log.Fatal(err)
+	}
+	assert.Equal(suite.T(), string(expected), strings.TrimSpace(w.Body.String()))
+
+	// Without token hint
+	r.PostForm = url.Values{"token": {rt.Token}}
+
+	// And run the function we want to test
+	w = httptest.NewRecorder()
+	suite.service.introspectHandler(w, r)
+
+	// Check the status code
+	assert.Equal(suite.T(), 200, w.Code)
+	// Check the response body
+	expected, err = json.Marshal(suite.service.IntrospectResponseRefreshToken(rt))
+	if err != nil {
+		log.Fatal(err)
+	}
+	assert.Equal(suite.T(), string(expected), strings.TrimSpace(w.Body.String()))
+}
+
+func (suite *OauthTestSuite) TestHandleIntrospectInactiveToken() {
+	// Make a request
+	r, err := http.NewRequest("POST", "http://1.2.3.4/something", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	r.SetBasicAuth("test_client", "test_secret")
+
+	// With access token hint
+	r.PostForm = url.Values{"token": {"unexisting_token"}, "token_type_hint": {accessTokenHint}}
+
+	// And run the function we want to test
+	w := httptest.NewRecorder()
+	suite.service.introspectHandler(w, r)
+
+	// Check the status code
+	assert.Equal(suite.T(), 200, w.Code)
+	// Check the response body
+	expected, err := json.Marshal(&IntrospectResponse{})
+	if err != nil {
+		log.Fatal(err)
+	}
+	assert.Equal(suite.T(), string(expected), strings.TrimSpace(w.Body.String()))
+
+	// With refresh token hint
+	r.PostForm = url.Values{"token": {"unexisting_token"}, "token_type_hint": {refreshTokenHint}}
+
+	// And run the function we want to test
+	w = httptest.NewRecorder()
+	suite.service.introspectHandler(w, r)
+
+	// Check the status code
+	assert.Equal(suite.T(), 200, w.Code)
+	// Check the response body
+	expected, err = json.Marshal(&IntrospectResponse{})
+	if err != nil {
+		log.Fatal(err)
+	}
+	assert.Equal(suite.T(), string(expected), strings.TrimSpace(w.Body.String()))
+
+	// Without token hint
+	r.PostForm = url.Values{"token": {"unexisting_token"}}
+
+	// And run the function we want to test
+	w = httptest.NewRecorder()
+	suite.service.introspectHandler(w, r)
+
+	// Check the status code
+	assert.Equal(suite.T(), 200, w.Code)
+	// Check the response body
+	expected, err = json.Marshal(&IntrospectResponse{})
+	if err != nil {
+		log.Fatal(err)
+	}
+	assert.Equal(suite.T(), string(expected), strings.TrimSpace(w.Body.String()))
+}

--- a/oauth/response.go
+++ b/oauth/response.go
@@ -9,3 +9,13 @@ type AccessTokenResponse struct {
 	Scope        string `json:"scope"`
 	RefreshToken string `json:"refresh_token"`
 }
+
+// IntrospectResponse ...
+type IntrospectResponse struct {
+	Active    bool   `json:"active"`
+	Scope     string `json:"scope,omitempty"`
+	ClientID  string `json:"client_id,omitempty"`
+	Username  string `json:"username,omitempty"`
+	TokenType string `json:"token_type,omitempty"`
+	ExpiresAt int    `json:"exp,omitempty"`
+}

--- a/oauth/routes.go
+++ b/oauth/routes.go
@@ -20,5 +20,11 @@ func newRoutes(service *Service) []routes.Route {
 			Pattern:     "/tokens",
 			HandlerFunc: service.tokensHandler,
 		},
+		routes.Route{
+			Name:        "oauth_introspect",
+			Method:      "POST",
+			Pattern:     "/introspect",
+			HandlerFunc: service.introspectHandler,
+		},
 	}
 }


### PR DESCRIPTION
New endpoint /v1/oauth/introspect.

Token introspection response can contains these of possible optional attributes

* scope
* client_id
* username
* token_type
* exp