### PR TITLE
Fix #49. Create user home dir in Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,10 @@ ENV GO111MODULE on
 # Chown the application directory to app user
 RUN chown -R app:app /go/src/github.com/RichardKnop/go-oauth2-server/
 
+# Create user's home directory
+RUN mkdir -p /home/app
+RUN chown app /home/app
+
 # Use the unprivileged user
 USER app
 


### PR DESCRIPTION
As mentioned at #49, docker-compose fails on `go install` because _go_ has no access to `/home/app` directory. This PR solves it.