### PR TITLE
Docker compose: Database is uninitialized and superuser password is not specified.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ services:
       POSTGRES_USER: "go_oauth2_server"
       POSTGRES_PASSWORD: ""
       POSTGRES_DB: "go_oauth2_server"
+      POSTGRES_HOST_AUTH_METHOD: "trust"
 
   app:
     container_name: go_oauth2_server


### PR DESCRIPTION
It solved by adding 

      POSTGRES_HOST_AUTH_METHOD: "trust" into the postgres section in docker-compose.yml

